### PR TITLE
Issue #SC-1351 Fix slug instead of channel

### DIFF
--- a/platform-modules/batch-models/src/main/scala/org/ekstep/analytics/util/HDFSFileUtils.scala
+++ b/platform-modules/batch-models/src/main/scala/org/ekstep/analytics/util/HDFSFileUtils.scala
@@ -25,6 +25,28 @@ class HDFSFileUtils(classNameStr: String, jobLogger: JobLogger.type ) {
     val dir = new File(dirName)
     purgeDirectory(dir)
   }
+  
+  // Gets first level sub-directories
+  def getSubdirectories(dirName: String): List[File] = {
+      val file = new File(dirName)
+      if (file.exists && file.isDirectory) {
+          val files = file.listFiles.filter(_.isDirectory).toList
+          files
+      } else if (file.exists && file.isFile) {
+        List[File](file)
+      } else {
+          List[File]();
+      }
+  }
+  
+  def renameDirectory(oldName: String, newName: String) {
+    val oldDir = new File(oldName)
+    if (oldDir.isDirectory()) {
+      oldDir.renameTo(new File(newName))
+      jobLogger.log(s"Renamed $oldName to $newName")
+      println(s"Renamed $oldName to $newName")
+    }
+  }
 
   def renameReport(tempDir: String, outDir: String, fileExt: String, fileNameSuffix: String = null) = {
     val regex = """\=.*/""".r // example path "somepath/partitionFieldName=12313144/part-0000.csv"


### PR DESCRIPTION
Earlier channel was the partition by attribute. It is learnt Portal team likes to have this only as slug attribute.

**Testing**
* Ensured a rootOrg had slug and channel as different strings and found in the logs, rename was successfully invoked and completed.
`Renamed /tmp/admin-user-reports/renamed/apekx to /tmp/admin-user-reports/renamed/apekx
Slug not found for - shadowchannel2
name = TestETL and slugname = Some(testetl)
Renamed /tmp/admin-user-reports/renamed/TestETL to /tmp/admin-user-reports/renamed/testetl
name = dikshapreprodcustodian and slugname = Some(dikshapreprodcustodian)
Renamed /tmp/admin-user-reports/renamed/dikshapreprodcustodian to /tmp/admin-user-reports/renamed/dikshapreprodcustodian
Slug not found for - __HIVE_DEFAULT_PARTITION__
Slug not found for - custchannel
name = as and slugname = Some(differAS)
Renamed /tmp/admin-user-reports/renamed/as to /tmp/admin-user-reports/renamed/differAS`

Table for reference
`cqlsh:sunbird> select id, channel, slug, rootorgid, isrootorg from organisation where id='01276175508980531215';

 id                   | channel | slug     | rootorgid            | isrootorg
----------------------+---------+----------+----------------------+-----------
 01276175508980531215 |      as | differAS | 01276175508980531215 |      True
`